### PR TITLE
Use ssh+git for installing plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Plugin:
 ```shell
 asdf plugin add tx
 # or
-asdf plugin add tx https://github.com/kundo/asdf-tx.git
+asdf plugin add tx ssh+git://git@github.com/kundo/asdf-plugin-tx.git
 ```
 
 tx:


### PR DESCRIPTION
This commit addresses two things:

* The repo name was misspelled in the installation instructions
* It changes the `asdf plugin add` definition to use the `ssh+git`
  protocol instead of `https`.

The reason for the latter change is that the repo is private, and most
of us don't necessarily have our local `git` configured to communicate
using `https`, and thus would have to enter a GitHub username and
password in order to install the plugin.

We do, however, all have some sort of SSH key configured that works with
our private GitHub repos, since we are able to clone this repo and run
its setup, so using `ssh+git` here means we shouldn't have to perform
extra authentication steps in a terminal.